### PR TITLE
update usage section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,13 @@ The simplest method of inclusion is a `<script>` tag after the video.js `<script
 ## Usage
 
 ```js
-var player = videojs('video');
-
-player.playlist([{
-  forward: 20,
-  back: 20
+videojs('videojs', {
+  plugins: {
+    seekButtons: {
+      forward: 15,
+      back: 15,
+    },
+  },
 });
 ```
 


### PR DESCRIPTION
Great little plugin here! I updated the README's usage section to be inline with Videojs's plugin usage documentation (https://github.com/videojs/video.js/blob/master/docs/guides/plugins.md). And because the existing example in the README is missing a closing bracket.

Unrelated: It would be great to see a Bower package for this project as well. :)
