### PR TITLE
fix: Workaround for Safari bug with rotateY

### DIFF
--- a/src/plugin.css
+++ b/src/plugin.css
@@ -36,9 +36,9 @@
         content: '\f116';
       }
       &.skip-forward .vjs-icon-placeholder::before {
-        transform: rotateY(180deg) rotate(-45deg);
-        -ms-transform: rotateY(180deg) rotate(-45deg); /* IE 9 */
-        -webkit-transform: rotateY(180deg) rotate(-45deg); /* Safari */
+        transform: scale(-1, 1) rotate(-45deg);
+        -ms-transform: scale(-1, 1) rotate(-45deg); /* IE 9 */
+        -webkit-transform: scale(-1, 1) rotate(-45deg); /* Safari */
         content: '\f116';
       }
     }


### PR DESCRIPTION
Uses alternative CSS as Safari has a bug with `rotateY`. Fixes #46 