### PR TITLE
Make requirement to include CSS in React app clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ The dist versions will be available from services which host npm packages such a
 ### Browserify/CommonJS
 
 When using with Browserify, install videojs-seek-buttons via npm and `require` the plugin as you would any other module.
+Make sure if using React to also `include "videojs-seek-buttons/dist/videojs-seek-buttons.css"`, otherwise the icons will not appear in the control bar.
 
 ```js
 var videojs = require('video.js');


### PR DESCRIPTION
Just added a small note in the readme to include the CSS file in a react app. I spent quite a few minutes hunting around for why my icons weren't showing up in the toolbar, so hopefully this can prevent that for someone else.