### PR TITLE
chore: Use conventional commit prefixes with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope


### PR DESCRIPTION
Dependabot's commit messages haven't been included in changelogs, adds config file to add add prefixes.